### PR TITLE
Add tooltip to dataset page

### DIFF
--- a/view/src/components/BiasDifferenceLabel.tsx
+++ b/view/src/components/BiasDifferenceLabel.tsx
@@ -1,16 +1,16 @@
 import { Dataset } from "../types/types";
 
 interface BiasDifferenceDisplayProps {
-  difference: number;
   dataset1: Dataset;
   dataset2: Dataset;
 }
 
 export default function BiasDifferenceDisplay({
-  difference,
   dataset1,
   dataset2,
 }: BiasDifferenceDisplayProps): JSX.Element {
+  const difference = 10 - dataset2.score - (10 - dataset1.score);
+
   return (
     <p className="mt-5 text-lg">
       Overall bias{" "}

--- a/view/src/components/CategoryInfoModal.tsx
+++ b/view/src/components/CategoryInfoModal.tsx
@@ -1,7 +1,7 @@
-import BiasProgressBar from "../components/BiasProgressBar";
-import Graph from "../components/Graph";
 import { Category } from "../types/types";
 import { capitalize } from "../utils/string";
+import BiasProgressBar from "./BiasProgressBar";
+import Graph from "./Graph";
 import Modal from "./Modal";
 
 interface SelectedCategoryModalProps {
@@ -9,7 +9,7 @@ interface SelectedCategoryModalProps {
   onClose: () => void;
 }
 
-export default function SelectedCategoryModal({
+export default function CategoryInfoModal({
   category,
   onClose,
 }: SelectedCategoryModalProps): JSX.Element {
@@ -57,6 +57,7 @@ export default function SelectedCategoryModal({
             aria-label={`Graph showing false positive rates for ${capitalize(
               category.name
             )} traits`}
+            valueToText={(value) => `${(value * 100).toFixed(0)}%`}
           />
           <div className="mt-32" />
         </div>

--- a/view/src/components/Graph.tsx
+++ b/view/src/components/Graph.tsx
@@ -10,6 +10,7 @@ interface GraphProps {
   zeroValueLabel: string;
   minValueLabel?: string;
   getColor: (value: number) => string;
+  valueToText?: (value: number) => string;
 }
 
 export default function Graph({
@@ -22,6 +23,7 @@ export default function Graph({
   zeroValueLabel,
   minValueLabel,
   getColor,
+  valueToText,
 }: GraphProps): ReactElement {
   const barWidth = 10;
   const gap = 2;
@@ -30,7 +32,7 @@ export default function Graph({
 
   return (
     <div className="flex flex-col items-center">
-      <p className="mb-4 text-lg text-center underline">{name}</p>
+      <p className="mb-8 text-lg text-center underline">{name}</p>
       <div className="w-max relative">
         <div
           className="flex"
@@ -67,7 +69,7 @@ export default function Graph({
             {entries.map((entry, index) => (
               <div
                 key={index}
-                className="h-full flex relative hover:bg-slate-100 hover:cursor-pointer"
+                className="h-full flex relative hover:bg-slate-100 hover:cursor-pointer group transition-colors"
                 style={{
                   width: `${barWidth / 4}rem`,
                   alignItems: "flex-end",
@@ -84,14 +86,29 @@ export default function Graph({
               >
                 {/* Bar */}
                 <div
-                  className={`bg-${getColor(entry.value)}`}
+                  className={`bg-${getColor(
+                    entry.value
+                  )} relative flex justify-center`}
                   style={{
                     height: `${(Math.abs(entry.value) / maxValue) * 100}%`,
                     width: `${barWidth / 4}rem`,
                     marginTop: entry.value < 0 ? `${height / 8}rem` : 0,
                     alignSelf: entry.value < 0 ? "flex-start" : "flex-end",
                   }}
-                ></div>
+                >
+                  <p
+                    className="transition-opacity opacity-0 group-hover:opacity-100"
+                    style={{
+                      alignSelf: entry.value < 0 ? "flex-end" : "flex-start",
+                      marginTop: entry.value < 0 ? "0rem" : "-1.75rem",
+                      marginBottom: entry.value < 0 ? "-1.75rem" : "0rem",
+                    }}
+                  >
+                    {valueToText
+                      ? valueToText(entry.value)
+                      : entry.value.toFixed(2)}
+                  </p>
+                </div>
                 {/* Label */}
                 <div
                   className="absolute w-max"

--- a/view/src/components/Tooltip.tsx
+++ b/view/src/components/Tooltip.tsx
@@ -1,0 +1,14 @@
+import { ReactElement } from "react";
+import { IoMdInformationCircleOutline } from "react-icons/io";
+
+interface TooltipProps {
+  text: string;
+}
+
+export default function Tooltip({ text }: TooltipProps): ReactElement {
+  return (
+    <div className="tooltip h-6 w-6 tooltip-bottom" data-tip={text}>
+      <IoMdInformationCircleOutline className="text-blue-500 h-full w-full" />
+    </div>
+  );
+}

--- a/view/src/pages/ComparePage.tsx
+++ b/view/src/pages/ComparePage.tsx
@@ -1,11 +1,11 @@
 import { ReactElement, useState } from "react";
+import BiasDifferenceDisplay from "../components/BiasDifferenceLabel";
+import CopyComparisonLinkButton from "../components/CopyComparisonLinkButton";
+import DatasetSelector from "../components/DatasetSelector";
 import Graph from "../components/Graph";
 import Modal from "../components/Modal";
 import { Dataset } from "../types/types";
 import { capitalize } from "../utils/string";
-import CopyComparisonLinkButton from "../components/CopyComparisonLinkButton";
-import DatasetSelector from "../components/DatasetSelector";
-import BiasDifferenceDisplay from "../components/BiasDifferenceDisplay";
 
 interface ComparePageProps {
   datasets: Dataset[];
@@ -24,14 +24,8 @@ export default function ComparePage({
 }: ComparePageProps): ReactElement {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
 
-  const difference =
-    selectedDataset1 && selectedDataset2
-      ? 10 - selectedDataset2.score - (10 - selectedDataset1.score)
-      : undefined;
-
   return (
     <div className="relative flex flex-col items-center">
-
       {/* Copy Link Button */}
       <CopyComparisonLinkButton
         selectedDataset1={selectedDataset1}
@@ -57,9 +51,8 @@ export default function ComparePage({
       </div>
 
       {/* Bias Difference Display */}
-      {difference !== undefined && (
+      {selectedDataset1 && selectedDataset2 && (
         <BiasDifferenceDisplay
-          difference={difference}
           dataset1={selectedDataset1!}
           dataset2={selectedDataset2!}
         />
@@ -74,8 +67,9 @@ export default function ComparePage({
             entries={selectedDataset1.categories.map((c, i) => ({
               name: c.name,
               value:
-                c.fprScore - 
-                selectedDataset2.categories.find((a) => a.name === c.name)!.fprScore,
+                c.fprScore -
+                selectedDataset2.categories.find((a) => a.name === c.name)!
+                  .fprScore,
             }))}
             getColor={(value) => (value < 0 ? "green-500" : "red-500")}
             maxValue={10}
@@ -100,15 +94,19 @@ export default function ComparePage({
                 entries={[
                   {
                     name: selectedDataset1!.name,
-                    value: selectedDataset1!.categories.find(
-                      (c) => c.name === selectedCategory
-                    )!.fprScore,
+                    value:
+                      10 -
+                      selectedDataset1!.categories.find(
+                        (c) => c.name === selectedCategory
+                      )!.fprScore,
                   },
                   {
                     name: selectedDataset2!.name,
-                    value: selectedDataset2!.categories.find(
-                      (c) => c.name === selectedCategory
-                    )!.fprScore,
+                    value:
+                      10 -
+                      selectedDataset2!.categories.find(
+                        (c) => c.name === selectedCategory
+                      )!.fprScore,
                   },
                 ]}
                 getColor={(value) => "blue-500"}

--- a/view/src/pages/DatasetPage.tsx
+++ b/view/src/pages/DatasetPage.tsx
@@ -3,6 +3,7 @@ import BiasProgressBar from "../components/BiasProgressBar";
 import CategoryInfoModal from "../components/CategoryInfoModal";
 import CopyLinkButton from "../components/CopyLinkButton";
 import Graph from "../components/Graph";
+import Tooltip from "../components/Tooltip";
 import { Category, Dataset } from "../types/types";
 import { getColorByScore } from "../utils/score";
 
@@ -91,7 +92,14 @@ export default function DatasetPage({ dataset }: GraphPageProps) {
       <CopyLinkButton datasetId={dataset.id} />
 
       {/* Overall Bias Section */}
-      <p className="mb-2 text-lg mt-5">Overall Bias Detected:</p>
+      <div className="flex items-center mt-5 mb-2 gap-1">
+        <p className="text-lg">Overall Bias Detected: </p>
+        <Tooltip
+          text={
+            "The overall bias is calculated by taking the mean of all the bias' detected by each category."
+          }
+        />
+      </div>
       <BiasProgressBar
         bias={10 - dataset.score}
         aria-label={`Overall bias score: ${10 - dataset.score}`}

--- a/view/src/pages/DatasetPage.tsx
+++ b/view/src/pages/DatasetPage.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import BiasProgressBar from "../components/BiasProgressBar";
+import CategoryInfoModal from "../components/CategoryInfoModal";
+import CopyLinkButton from "../components/CopyLinkButton";
 import Graph from "../components/Graph";
 import { Category, Dataset } from "../types/types";
 import { getColorByScore } from "../utils/score";
-import CopyLinkButton from "../components/CopyLinkButton";
-import SelectedCategoryModal from "../components/SelectCategoryModal";
 
 const raceData = [
   {
@@ -92,14 +92,14 @@ export default function DatasetPage({ dataset }: GraphPageProps) {
 
       {/* Overall Bias Section */}
       <p className="mb-2 text-lg mt-5">Overall Bias Detected:</p>
-      <BiasProgressBar 
-      bias={10 - dataset.score} 
-      aria-label={`Overall bias score: ${10 - dataset.score}`}
+      <BiasProgressBar
+        bias={10 - dataset.score}
+        aria-label={`Overall bias score: ${10 - dataset.score}`}
       />
       <p className="mt-5 max-w-96 mb-10 text-md whitespace-pre-line">
         {dataset.description}
       </p>
-      
+
       {/* Graph Section */}
       <Graph
         name={"Bias Detected by Category"}
@@ -122,7 +122,7 @@ export default function DatasetPage({ dataset }: GraphPageProps) {
 
       {/* Modal Section */}
       {selectedCategory && (
-        <SelectedCategoryModal
+        <CategoryInfoModal
           category={selectedCategory}
           onClose={() => setSelectedCategory(null)}
         />


### PR DESCRIPTION
Add a tooltip icon beside overall bias on the main dataset page that displays a description of how the overall bias is calculated on hover.